### PR TITLE
fix: remove pry require

### DIFF
--- a/lib/simplecov-tailwindcss.rb
+++ b/lib/simplecov-tailwindcss.rb
@@ -4,7 +4,6 @@ require "erb"
 require "cgi"
 require "fileutils"
 require "digest/sha1"
-require "pry"
 
 # Ensure we are using a compatible version of SimpleCov
 major, minor, patch = SimpleCov::VERSION.scan(/\d+/).first(3).map(&:to_i)
@@ -49,7 +48,7 @@ module SimpleCov
         end
       end
 
-    private
+      private
 
       def template(name)
         ERB.new(File.read(File.join(
@@ -63,7 +62,7 @@ module SimpleCov
 
       def asset_output_path
         return @asset_output_path if defined?(@asset_output_path) &&
-                                     @asset_output_path
+          @asset_output_path
 
         @asset_output_path = File.join(
           output_path, "dist", SimpleCov::Formatter::TailwindFormatter::VERSION
@@ -93,7 +92,7 @@ module SimpleCov
       def generate_table_column_head(name)
         template("table_column_head").result(binding)
       end
-      
+
       # rubocop:disable Lint/SelfAssignment, Style/RedundantRegexpEscape
       def generate_group_page(title, files)
         title_id = title.gsub(/^[^a-zA-Z]+/, "").gsub(/[^a-zA-Z0-9\-\_]/, "")


### PR DESCRIPTION
# Description

Remove pry require that caused downhill issues when trying to use this. I can remove the formatting changes but it was just removing white space so wasn't sure if you'd want it or not.

Works great now!

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Steps:
1. Had just downloaded Ruby 2.7.2, but hadn't installed Rails so I did that
2. Created clean new Rails app
3. Added a pages controller and hello world view 
4. Installed simplecov
5. Added test to the test suite, verified that simplecov was working as expected.
6. Installed this gem per instructions
7. Received the output in this [gist](https://gist.github.com/andrewmcodes/832eba1e9ad932d7f42335288127cd16)
8. Forked and installed gem locally, pointed app gemfile to it
9. Removed require
10. It worked!

![after](https://user-images.githubusercontent.com/18423853/95686855-7d66f500-0bce-11eb-987f-b0a12f03c569.png)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
