### PR TITLE
add padding in groups to be able to see the last item

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,7 @@ SimpleCov.start do
   enable_coverage :branch
   add_filter "/test/"
   add_group "Library", "/lib"
+  10.times { |i| add_group "Test #{i + 1}", "/lib" } if ENV["TEST_LONG_LIST_OF_GROUPS"]
 end
 
 SimpleCov.formatters = [

--- a/views/main.erb
+++ b/views/main.erb
@@ -91,7 +91,7 @@
     </div>
     <div class="supports-backdrop-blur:bg-white/60 fixed h-full w-28 overflow-y-auto border-r border-solid border-slate-200 bg-white/95 backdrop-blur transition-colors duration-500 dark:border-slate-50/[0.2] dark:bg-transparent">
       <div class="flex w-full flex-col items-center">
-        <div class="w-full flex-1 space-y-1 p-2">
+        <div class="w-full flex-1 space-y-1 p-2 pb-20">
           <div class="nav group flex w-full flex-col items-center rounded-md p-3 text-xs font-medium cursor-pointer bg-blue-700 text-slate-300" data-action="click->navigation#navigateEvent" data-index="All Files">
             <svg class="h-6 w-6 group-hover:text-slate-300" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />


### PR DESCRIPTION
# Description

When many groups exist, last group is hidden past the screen.

Fixes #57 (partially)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `TEST_LONG_LIST_OF_GROUPS=1 yarn test`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
