### PR TITLE
Add red badges for uncovered branches

### DIFF
--- a/views/dialog.erb
+++ b/views/dialog.erb
@@ -38,7 +38,8 @@
               <% end %>
               <% if branchable_result? %>
                 <% file.branches_for_line(line.number).each do |branch_type, hit_count| %>
-                  <span class="inline-flex items-center ml-1 px-2.5 py-0.5 rounded-full text-xs font-medium leading-4 bg-blue-700 text-white float-right" title="<%= branch_type %> branch hit <%= hit_count %> times">
+                  <% color = hit_count > 0 ? "bg-blue-700 text-white" : "bg-red-500 text-slate-100" %>
+                  <span class="inline-flex items-center ml-1 px-2.5 py-0.5 rounded-full text-xs font-medium leading-4 float-right <%= color %>" title="<%= branch_type %> branch hit <%= hit_count %> times">
                     <%= branch_type %>: <%= hit_count %>
                   </span>
                 <% end %>

--- a/views/file_detail.erb
+++ b/views/file_detail.erb
@@ -19,7 +19,7 @@
                   <%= format_number(file.lines.count) %>
                 </p>
                 <p class="mt-2 flex items-center text-sm lg:mt-0 lg:ml-6">
-                  <span class="font-bold pr-2">Relevent Lines:</span>
+                  <span class="font-bold pr-2">Relevant Lines:</span>
                   <%= format_number(file.covered_lines.count + file.missed_lines.count) %>
                 </p>
                 <p class="mt-2 flex items-center text-sm lg:mt-0 lg:ml-6">


### PR DESCRIPTION


# Description

Finding branches without cover, in the current file details implementation, is hard, due the badges having the same colour. With this commit, we implement red badges for the uncovered branches, allowing to easily spot them.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

![image](https://github.com/chiefpansancolt/simplecov-tailwindcss/assets/22743/3aa1fbd7-c678-44d3-a7f3-61d49ab6a949)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
